### PR TITLE
Ubuntu 16.04 中 Lotserver 内核安装与检测不一致

### DIFF
--- a/tcp.sh
+++ b/tcp.sh
@@ -590,7 +590,7 @@ check_sys_Lotsever(){
 	elif [[ "${release}" == "ubuntu" ]]; then
 		if [[ ${version} -ge "12" ]]; then
 			if [[ ${bit} == "x64" ]]; then
-				kernel_version="4.4.0-47"
+				kernel_version="4.8.0-36"
 				installlot
 			elif [[ ${bit} == "x32" ]]; then
 				kernel_version="3.13.0-29"
@@ -609,7 +609,7 @@ check_status(){
 	kernel_version_full=`uname -r`
 	if [[ ${kernel_version_full} = "4.14.129-bbrplus" ]]; then
 		kernel_status="BBRplus"
-	elif [[ ${kernel_version} = "3.10.0" || ${kernel_version} = "3.16.0" || ${kernel_version} = "3.2.0" || ${kernel_version} = "4.4.0" || ${kernel_version} = "3.13.0"  || ${kernel_version} = "2.6.32" || ${kernel_version} = "4.9.0" ]]; then
+	elif [[ ${kernel_version} = "3.10.0" || ${kernel_version} = "3.16.0" || ${kernel_version} = "3.2.0" || ${kernel_version} = "4.8.0" || ${kernel_version} = "3.13.0"  || ${kernel_version} = "2.6.32" || ${kernel_version} = "4.9.0" ]]; then
 		kernel_status="Lotserver"
 	elif [[ `echo ${kernel_version} | awk -F'.' '{print $1}'` == "4" ]] && [[ `echo ${kernel_version} | awk -F'.' '{print $2}'` -ge 9 ]] || [[ `echo ${kernel_version} | awk -F'.' '{print $1}'` == "5" ]]; then
 		kernel_status="BBR"


### PR DESCRIPTION
tcp.sh中调用的Ubuntu内核安装脚本Debian_Kernel.sh中为Ubuntu安装的内核版本为`4.8.0-36-generic`:
https://github.com/chiakge/Linux-NetSpeed/blob/64df10495e7865dd819d7901fd26cfec2b163b46/Debian_Kernel.sh#L8-L17

tcp.sh中的kernel_version检测的则是4.4.0-47:
https://github.com/chiakge/Linux-NetSpeed/blob/64df10495e7865dd819d7901fd26cfec2b163b46/tcp.sh#L590-L600
https://github.com/chiakge/Linux-NetSpeed/blob/64df10495e7865dd819d7901fd26cfec2b163b46/tcp.sh#L612-L613

这将导致在移除冗余内核时将新安装的`4.8.0-36-generic`版本内核一并移除，导致无法正常引导。